### PR TITLE
Do not create 'auditCollection' in the 'local' database

### DIFF
--- a/jstests/audit/_audit_helpers.js
+++ b/jstests/audit/_audit_helpers.js
@@ -108,7 +108,7 @@ var auditTestShard = function(name, fn, serverParams) {
 
 // Drop the existing audit events collection, import
 // the audit json file, then return the new collection.
-var getAuditEventsCollection = function(m, primary, useAuth) {
+var getAuditEventsCollection = function(m, dbname, primary, useAuth) {
     var auth = ((useAuth !== undefined) && (useAuth != false)) ? true : false;
     if (auth) {
         var adminDB = m.getDB('admin');
@@ -120,7 +120,7 @@ var getAuditEventsCollection = function(m, primary, useAuth) {
     var auditOptions = m.getDB('admin').runCommand('auditGetOptions');
     var auditPath = auditOptions.path;
     var auditCollectionName = 'auditCollection';
-    return loadAuditEventsIntoCollection(m, auditPath, 'local', auditCollectionName, primary, auth);
+    return loadAuditEventsIntoCollection(m, auditPath, dbname, auditCollectionName, primary, auth);
 }
 
 // Load any file into a named collection.

--- a/jstests/audit/audit_authenticate.js
+++ b/jstests/audit/audit_authenticate.js
@@ -25,7 +25,7 @@ auditTest(
 
         assert(testDB.auth('john', 'john'), "could not auth as john (pwd john)");
 
-        var auditColl = getAuditEventsCollection(m, undefined, true);
+        var auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: 'authenticate',
             ts: withinTheLastFewSeconds(),
@@ -40,7 +40,7 @@ auditTest(
         // ErrorCodes::AuthenticationFailed in src/mongo/base/error_codes.err
         var authenticationFailureCode = 18;
 
-        var auditColl = getAuditEventsCollection(m, undefined, true);
+        var auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: 'authenticate',
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_command.js
+++ b/jstests/audit/audit_authz_command.js
@@ -26,7 +26,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_current_op.js
+++ b/jstests/audit/audit_authz_current_op.js
@@ -27,7 +27,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_delete.js
+++ b/jstests/audit/audit_authz_delete.js
@@ -35,7 +35,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_find.js
+++ b/jstests/audit/audit_authz_find.js
@@ -39,7 +39,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_get_more.js
+++ b/jstests/audit/audit_authz_get_more.js
@@ -52,7 +52,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_insert.js
+++ b/jstests/audit/audit_authz_insert.js
@@ -33,7 +33,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_kill_op.js
+++ b/jstests/audit/audit_authz_kill_op.js
@@ -37,7 +37,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_authz_update.js
+++ b/jstests/audit/audit_authz_update.js
@@ -33,7 +33,7 @@ auditTest(
         testDB.logout();
 
         // Verify that audit event was inserted.
-        auditColl = getAuditEventsCollection(m, undefined, true);
+        auditColl = getAuditEventsCollection(m, testDBName, undefined, true);
         assert.eq(1, auditColl.count({
             atype: "authCheck",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_create_collection.js
+++ b/jstests/audit/audit_create_collection.js
@@ -14,7 +14,7 @@ auditTest(
         testDB = m.getDB(testDBName);
         assert.commandWorked(testDB.createCollection('foo'));
 
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "createCollection",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_create_database.js
+++ b/jstests/audit/audit_create_database.js
@@ -15,7 +15,7 @@ auditTest(
         assert.commandWorked(testDB.dropDatabase());
         assert.commandWorked(testDB.createCollection('foo'));
 
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "createDatabase",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_create_index.js
+++ b/jstests/audit/audit_create_index.js
@@ -18,7 +18,7 @@ auditTest(
 
         assert.commandWorked(testDB.coll.createIndex({ b: 1 }, { name: 'hot', background: true }));
 
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
 
         assert.eq(1, auditColl.count({
             atype: "createIndex",

--- a/jstests/audit/audit_drop_collection.js
+++ b/jstests/audit/audit_drop_collection.js
@@ -17,7 +17,7 @@ auditTest(
         assert.writeOK(coll.insert({ a: 17 }));
         assert(coll.drop());
 
-        var auditColl = getAuditEventsCollection(m);
+        var auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "dropCollection",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_drop_database.js
+++ b/jstests/audit/audit_drop_database.js
@@ -15,7 +15,7 @@ auditTest(
         assert.writeOK(testDB.getCollection('foo').insert({ a: 1 }));
         assert.commandWorked(testDB.dropDatabase());
 
-        var auditColl = getAuditEventsCollection(m);
+        var auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "dropDatabase",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_drop_index.js
+++ b/jstests/audit/audit_drop_index.js
@@ -18,7 +18,7 @@ auditTest(
         assert.commandWorked(coll.createIndex({ a: 1 }, { name: idxName }));
         assert.commandWorked(coll.dropIndex({ a: 1 }));
 
-        var auditColl = getAuditEventsCollection(m);
+        var auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "dropIndex",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_log_application_message.js
+++ b/jstests/audit/audit_log_application_message.js
@@ -6,13 +6,15 @@ if (TestData.testData !== undefined) {
     load('jstests/audit/_audit_helpers.js');
 }
 
+var testDBName = 'audit_log_application_message';
+
 auditTest(
     'logApplicationMessage',
     function(m) {
         var msg = "it's a trap!"
         assert.commandWorked(m.getDB('admin').runCommand({ logApplicationMessage: msg }));
 
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "applicationMessage",
             ts: withinTheLastFewSeconds(),

--- a/jstests/audit/audit_log_rotate.js
+++ b/jstests/audit/audit_log_rotate.js
@@ -34,15 +34,15 @@ auditTest(
         assert(testDB.getCollection('foo').drop());
 
         // There should be something in the audit log since we created 'test.foo'
-        assert.neq(0, getAuditEventsCollection(m).count(),
+        assert.neq(0, getAuditEventsCollection(m, testDBName).count(),
                    "strange: no audit events before rotate.");
 
         // Rotate the server log. The audit log rotates with it.
         // Once rotated, the audit log should be empty.
         assert.commandWorked(m.getDB('admin').runCommand({ logRotate: 1 }));
-        var auditLogAfterRotate = getAuditEventsCollection(m).find({ 
+        var auditLogAfterRotate = getAuditEventsCollection(m, testDBName).find({ 
             // skip audit events that will be triggered by getAuditEventsCollection itself
-            'params.ns': { $ne: 'local.auditCollection' }
+            'params.ns': { $ne: testDBName + '.auditCollection' }
         }).toArray();
         assert.eq(0, auditLogAfterRotate.length,
                   "Audit log has old events after rotate: " + tojson(auditLogAfterRotate));

--- a/jstests/audit/audit_rename_collection.js
+++ b/jstests/audit/audit_rename_collection.js
@@ -20,7 +20,7 @@ auditTest(
         assert.commandWorked(testDB.createCollection(oldName));
         assert.commandWorked(testDB.getCollection(oldName).renameCollection(newName));
 
-        var auditColl = getAuditEventsCollection(m);
+        var auditColl = getAuditEventsCollection(m, testDBName);
         var checkAuditLogForSingleRename = function() {
             assert.eq(1, auditColl.count({
                 atype: "renameCollection",

--- a/jstests/audit/audit_replset_reconfig.js
+++ b/jstests/audit/audit_replset_reconfig.js
@@ -8,7 +8,7 @@ if (TestData.testData !== undefined) {
     load('jstests/replsets/rslib.js');
 }
 
-var testDBName = 'audit_create_collection';
+var testDBName = 'audit_replset_reconfig';
 
 auditTestRepl(
     'replSetReconfig',
@@ -33,7 +33,7 @@ auditTestRepl(
         replTest.nodes.forEach(function(m) { 
             print('audit check looking for old, new: ' +tojson(oldConfig)+', '+tojson(newConfig));
             // We need to import the audit events collection into the master node.
-            auditColl = getAuditEventsCollection(m, replTest.getPrimary());
+            auditColl = getAuditEventsCollection(m, testDBName, replTest.getPrimary());
             assert.eq(1, auditColl.count({
                 atype: "replSetReconfig",
                 // Allow timestamps up to 20 seconds old, since replSetReconfig may be slow

--- a/jstests/audit/audit_shutdown.js
+++ b/jstests/audit/audit_shutdown.js
@@ -1,4 +1,4 @@
-// test that createColleciton gets audited
+// test that shutdownServer gets audited
 
 if (TestData.testData !== undefined) {
     load(TestData.testData + '/audit/_audit_helpers.js');
@@ -6,13 +6,15 @@ if (TestData.testData !== undefined) {
     load('jstests/audit/_audit_helpers.js');
 }
 
+var testDBName = 'audit_shutdown';
+
 auditTest(
     'shutdown',
     function(m, restartServer) {
         m.getDB('admin').shutdownServer();
         m = restartServer();
 
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "shutdown",
             // Give 10 seconds of slack in case shutdown / restart was particularly slow

--- a/jstests/audit/audit_system_users.js
+++ b/jstests/audit/audit_system_users.js
@@ -20,7 +20,7 @@ auditTest(
         var userObj = { user: 'john', pwd: 'john', roles: [ { role:'userAdmin', db:testDBName} ] };
         testDB.createUser(userObj);
 
-        var auditColl = getAuditEventsCollection(m);
+        var auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "createUser",
             ts: withinTheLastFewSeconds(),
@@ -35,7 +35,7 @@ auditTest(
         testDB.updateUser(userObj.user, updateObj);
         assert.eq(1, adminDB.system.users.count({ user: userObj.user, roles: updateObj.roles }),
                      "system.users update did not update role for user: " + userObj.user);
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "updateUser",
             ts: withinTheLastFewSeconds(),
@@ -50,7 +50,7 @@ auditTest(
         testDB.removeUser(userObj.user);
         assert.eq(0, testDB.system.users.count({ user: userObj.user }),
                      "removeUser did not remove user:" + userObj.user);
-        auditColl = getAuditEventsCollection(m);
+        auditColl = getAuditEventsCollection(m, testDBName);
         assert.eq(1, auditColl.count({
             atype: "dropUser",
             ts: withinTheLastFewSeconds(),


### PR DESCRIPTION
After commit b8e6d89 Collection in the 'local' database cannot be dropped by the 'admin' user
created in _audit_helpers.js. Anyway it is not necessary to create 'auditCollection'
in the 'local' database

(cherry picked from commit e41b59597c0a2cd3895a1714f2bb4acc53cb8467)